### PR TITLE
Use base path for the REST WHIP API

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -103,7 +103,7 @@ function addOrUpdateEndpoint(endpoint) {
 						if(result) {
 							// Send the DELETE to the endpoint
 							$.ajax({
-								url: endpoint.resource,
+								url: rest + '/resource/' + id,,
 								beforeSend: function(xhr) {
 									if(endpoint.token)
 										xhr.setRequestHeader('Authorization', 'Bearer ' + endpoint.token);


### PR DESCRIPTION
Use base path for the REST WHIP API, otherwise the Teardown Button in the WebUI doesn't work while hosted behind a reverse proxy.

<img width="683" alt="Screenshot 2022-07-12 at 12 59 37" src="https://user-images.githubusercontent.com/2962587/178485023-3fdbfca7-fbdb-4350-86db-0717f8669e3e.png">
 