### PR TITLE
Fix mid-check condition for video forwarding

### DIFF
--- a/src/whip-janus.js
+++ b/src/whip-janus.js
@@ -237,7 +237,7 @@ var whipJanus = function(janusConfig) {
 						session.audioMid = mid[1];
 					else if(type === "video" && !session.videoMid)
 						session.videoMid = mid[1];
-					if(session.audioMid && session.audioMid)
+					if(session.audioMid && session.videoMid)
 						break;
 				}
 			}


### PR DESCRIPTION
This PR fixes an error in the multistream/forwarding behavior that caused it to stop processing the offer SDP before finding a video mid.

The condition was intended to break the loop once both an audio and video mid are found, since no more SDP lines need to be processed. Instead, it broke prematurely, after finding only an audio mid.